### PR TITLE
Add PBKDF2 support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+* Support for the PBKDF2 key-derivation function (#1)
+
 ## [0.1.0] - 2016-12-12
 
 Initial release. Includes a wrapper for the `CommonDigestSPI` API.

--- a/commoncrypto-sys/src/lib.rs
+++ b/commoncrypto-sys/src/lib.rs
@@ -143,6 +143,28 @@ pub struct CCDigestCtx {
     context: [u8; CC_DIGEST_SIZE],
 }
 
+/// Algorithm for use with `CCKeyDerivationPBKDF()``
+#[repr(C)]
+pub enum CCPBKDFAlgorithm {
+    /// PBKDF2
+    kCCPBKDF2 = 2,
+}
+
+/// Pseudo-random algorithm to use with `CCKeyDerivationPBKDF()`
+#[repr(C)]
+pub enum CCPseudoRandomAlgorithm {
+    /// SHA-1
+    kCCPRFHmacAlgSHA1 = 1,
+    /// SHA-224
+    kCCPRFHmacAlgSHA224 = 2,
+    /// SHA-256
+    kCCPRFHmacAlgSHA256 = 3,
+    /// SHA-384
+    kCCPRFHmacAlgSHA384 = 4,
+    /// SHA-512
+    kCCPRFHmacAlgSHA512 = 5,
+}
+
 extern "C" {
     /// Initializes MD5 hasher. See `man 3cc CC_MD5` for details.
     pub fn CC_MD5_Init(ctx: *mut CC_MD5_CTX) -> c_int;
@@ -200,4 +222,7 @@ extern "C" {
     pub fn CCDigestGetBlockSizeFromRef(ctx: *mut CCDigestCtx) -> usize;
     /// Provides the digest output size of the digest algorithm. Returns `0` on failure.
     pub fn CCDigestGetOutputSizeFromRef(ctx: *mut CCDigestCtx) -> usize;
+
+    /// Derive a key from a user-supplied password via PBKDF2
+    pub fn CCKeyDerivationPBKDF(algorithm: CCPBKDFAlgorithm, password: *const u8, passwordLen: usize, salt: *const u8, saltLen: usize, prf: CCPseudoRandomAlgorithm, rounds: u32, derivedKey: *mut u8, derivedKeyLen: usize) -> c_int;
 }

--- a/commoncrypto-sys/src/lib.rs
+++ b/commoncrypto-sys/src/lib.rs
@@ -143,7 +143,7 @@ pub struct CCDigestCtx {
     context: [u8; CC_DIGEST_SIZE],
 }
 
-/// Algorithm for use with `CCKeyDerivationPBKDF()``
+/// Algorithm for use with `CCKeyDerivationPBKDF()`
 #[repr(C)]
 pub enum CCPBKDFAlgorithm {
     /// PBKDF2

--- a/commoncrypto-sys/src/lib.rs
+++ b/commoncrypto-sys/src/lib.rs
@@ -143,14 +143,14 @@ pub struct CCDigestCtx {
     context: [u8; CC_DIGEST_SIZE],
 }
 
-/// Algorithm for use with `CCKeyDerivationPBKDF()`
+/// Algorithm for use with `CCKeyDerivationPBKDF()`.
 #[repr(C)]
 pub enum CCPBKDFAlgorithm {
     /// PBKDF2
     kCCPBKDF2 = 2,
 }
 
-/// Pseudo-random algorithm to use with `CCKeyDerivationPBKDF()`
+/// Pseudo-random algorithm to use with `CCKeyDerivationPBKDF()`.
 #[repr(C)]
 pub enum CCPseudoRandomAlgorithm {
     /// SHA-1
@@ -223,7 +223,7 @@ extern "C" {
     /// Provides the digest output size of the digest algorithm. Returns `0` on failure.
     pub fn CCDigestGetOutputSizeFromRef(ctx: *mut CCDigestCtx) -> usize;
 
-    /// Derive a key from a user-supplied password via PBKDF2
+    /// Derive a key from a user-supplied password via PBKDF2.
     pub fn CCKeyDerivationPBKDF(algorithm: CCPBKDFAlgorithm,
                                 password: *const u8,
                                 passwordLen: usize,

--- a/commoncrypto-sys/src/lib.rs
+++ b/commoncrypto-sys/src/lib.rs
@@ -224,5 +224,14 @@ extern "C" {
     pub fn CCDigestGetOutputSizeFromRef(ctx: *mut CCDigestCtx) -> usize;
 
     /// Derive a key from a user-supplied password via PBKDF2
-    pub fn CCKeyDerivationPBKDF(algorithm: CCPBKDFAlgorithm, password: *const u8, passwordLen: usize, salt: *const u8, saltLen: usize, prf: CCPseudoRandomAlgorithm, rounds: u32, derivedKey: *mut u8, derivedKeyLen: usize) -> c_int;
+    pub fn CCKeyDerivationPBKDF(algorithm: CCPBKDFAlgorithm,
+                                password: *const u8,
+                                passwordLen: usize,
+                                salt: *const u8,
+                                saltLen: usize,
+                                prf: CCPseudoRandomAlgorithm,
+                                rounds: u32,
+                                derivedKey: *mut u8,
+                                derivedKeyLen: usize)
+                                -> c_int;
 }

--- a/commoncrypto-sys/tests/pbkdf2.rs
+++ b/commoncrypto-sys/tests/pbkdf2.rs
@@ -14,12 +14,12 @@ const SALT2: &'static str = "saltSALTsaltSALTsaltSALTsaltSALTsalt";
 const PASSWORD3: &'static str = "pass\0word";
 const SALT3: &'static str = "sa\0lt";
 
-const DERIVED1:        &'static str = "0c60c80f961f0e71f3a9b524af6012062fe037a6";
-const DERIVED2:        &'static str = "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957";
-const DERIVED4096:     &'static str = "4b007901b765489abead49d926f721d065a429c1";
+const DERIVED1: &'static str = "0c60c80f961f0e71f3a9b524af6012062fe037a6";
+const DERIVED2: &'static str = "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957";
+const DERIVED4096: &'static str = "4b007901b765489abead49d926f721d065a429c1";
 const DERIVED16777216: &'static str = "eefe3d61cd4da4e4e9945b3d6ba2158c2634e984";
-const DERIVED4096_2:   &'static str = "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038";
-const DERIVED4096_3:   &'static str = "56fa6aa75548099dcc37d7f03425e0c3";
+const DERIVED4096_2: &'static str = "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038";
+const DERIVED4096_3: &'static str = "56fa6aa75548099dcc37d7f03425e0c3";
 
 macro_rules! test_pbkdf2 {
     (
@@ -51,7 +51,27 @@ macro_rules! test_pbkdf2 {
 
 test_pbkdf2!(pbkdf2_1, kCCPRFHmacAlgSHA1, PASSWORD, SALT, 1, DERIVED1);
 test_pbkdf2!(pbkdf2_2, kCCPRFHmacAlgSHA1, PASSWORD, SALT, 2, DERIVED2);
-test_pbkdf2!(pbkdf2_4096, kCCPRFHmacAlgSHA1, PASSWORD, SALT, 4096, DERIVED4096);
-test_pbkdf2!(pbkdf2_16777216, kCCPRFHmacAlgSHA1, PASSWORD, SALT, 16777216, DERIVED16777216);
-test_pbkdf2!(pbkdf2_4096_2, kCCPRFHmacAlgSHA1, PASSWORD2, SALT2, 4096, DERIVED4096_2);
-test_pbkdf2!(pbkdf2_4096_3, kCCPRFHmacAlgSHA1, PASSWORD3, SALT3, 4096, DERIVED4096_3);
+test_pbkdf2!(pbkdf2_4096,
+             kCCPRFHmacAlgSHA1,
+             PASSWORD,
+             SALT,
+             4096,
+             DERIVED4096);
+test_pbkdf2!(pbkdf2_16777216,
+             kCCPRFHmacAlgSHA1,
+             PASSWORD,
+             SALT,
+             16777216,
+             DERIVED16777216);
+test_pbkdf2!(pbkdf2_4096_2,
+             kCCPRFHmacAlgSHA1,
+             PASSWORD2,
+             SALT2,
+             4096,
+             DERIVED4096_2);
+test_pbkdf2!(pbkdf2_4096_3,
+             kCCPRFHmacAlgSHA1,
+             PASSWORD3,
+             SALT3,
+             4096,
+             DERIVED4096_3);

--- a/commoncrypto-sys/tests/pbkdf2.rs
+++ b/commoncrypto-sys/tests/pbkdf2.rs
@@ -1,0 +1,57 @@
+extern crate commoncrypto_sys;
+extern crate hex;
+
+use hex::{ToHex, FromHex};
+
+// These password, salts, rounds and derived key values come from the test
+// vectors stated in RFC 6070
+const PASSWORD: &'static str = "password";
+const SALT: &'static str = "salt";
+
+const PASSWORD2: &'static str = "passwordPASSWORDpassword";
+const SALT2: &'static str = "saltSALTsaltSALTsaltSALTsaltSALTsalt";
+
+const PASSWORD3: &'static str = "pass\0word";
+const SALT3: &'static str = "sa\0lt";
+
+const DERIVED1:        &'static str = "0c60c80f961f0e71f3a9b524af6012062fe037a6";
+const DERIVED2:        &'static str = "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957";
+const DERIVED4096:     &'static str = "4b007901b765489abead49d926f721d065a429c1";
+const DERIVED16777216: &'static str = "eefe3d61cd4da4e4e9945b3d6ba2158c2634e984";
+const DERIVED4096_2:   &'static str = "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038";
+const DERIVED4096_3:   &'static str = "56fa6aa75548099dcc37d7f03425e0c3";
+
+macro_rules! test_pbkdf2 {
+    (
+        $test_name: ident,
+        $prf_algorithm: ident,
+        $pw: ident,
+        $salt: ident,
+        $rounds: expr,
+        $expected_dkey: ident
+    ) => {
+        #[test]
+        fn $test_name() {
+            let derived_len = Vec::<u8>::from_hex($expected_dkey).expect("dkey from hex").len();
+            let mut pw_derived = vec![0u8; derived_len];
+            unsafe {
+                assert_eq!(0, commoncrypto_sys::CCKeyDerivationPBKDF(
+                    commoncrypto_sys::CCPBKDFAlgorithm::kCCPBKDF2,
+                    $pw.as_ptr(), $pw.len(),
+                    $salt.as_ptr(), $salt.len(),
+                    commoncrypto_sys::CCPseudoRandomAlgorithm::$prf_algorithm,
+                    $rounds,
+                    pw_derived.as_mut_ptr(), pw_derived.len()
+                ));
+            }
+            assert_eq!($expected_dkey, pw_derived.to_hex());
+        }
+    }
+}
+
+test_pbkdf2!(pbkdf2_1, kCCPRFHmacAlgSHA1, PASSWORD, SALT, 1, DERIVED1);
+test_pbkdf2!(pbkdf2_2, kCCPRFHmacAlgSHA1, PASSWORD, SALT, 2, DERIVED2);
+test_pbkdf2!(pbkdf2_4096, kCCPRFHmacAlgSHA1, PASSWORD, SALT, 4096, DERIVED4096);
+test_pbkdf2!(pbkdf2_16777216, kCCPRFHmacAlgSHA1, PASSWORD, SALT, 16777216, DERIVED16777216);
+test_pbkdf2!(pbkdf2_4096_2, kCCPRFHmacAlgSHA1, PASSWORD2, SALT2, 4096, DERIVED4096_2);
+test_pbkdf2!(pbkdf2_4096_3, kCCPRFHmacAlgSHA1, PASSWORD3, SALT3, 4096, DERIVED4096_3);

--- a/commoncrypto-sys/tests/pbkdf2.rs
+++ b/commoncrypto-sys/tests/pbkdf2.rs
@@ -8,18 +8,8 @@ use hex::{ToHex, FromHex};
 const PASSWORD: &'static str = "password";
 const SALT: &'static str = "salt";
 
-const PASSWORD2: &'static str = "passwordPASSWORDpassword";
-const SALT2: &'static str = "saltSALTsaltSALTsaltSALTsaltSALTsalt";
-
-const PASSWORD3: &'static str = "pass\0word";
-const SALT3: &'static str = "sa\0lt";
-
 const DERIVED1: &'static str = "0c60c80f961f0e71f3a9b524af6012062fe037a6";
-const DERIVED2: &'static str = "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957";
 const DERIVED4096: &'static str = "4b007901b765489abead49d926f721d065a429c1";
-const DERIVED16777216: &'static str = "eefe3d61cd4da4e4e9945b3d6ba2158c2634e984";
-const DERIVED4096_2: &'static str = "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038";
-const DERIVED4096_3: &'static str = "56fa6aa75548099dcc37d7f03425e0c3";
 
 macro_rules! test_pbkdf2 {
     (
@@ -50,28 +40,9 @@ macro_rules! test_pbkdf2 {
 }
 
 test_pbkdf2!(pbkdf2_1, kCCPRFHmacAlgSHA1, PASSWORD, SALT, 1, DERIVED1);
-test_pbkdf2!(pbkdf2_2, kCCPRFHmacAlgSHA1, PASSWORD, SALT, 2, DERIVED2);
 test_pbkdf2!(pbkdf2_4096,
              kCCPRFHmacAlgSHA1,
              PASSWORD,
              SALT,
              4096,
              DERIVED4096);
-test_pbkdf2!(pbkdf2_16777216,
-             kCCPRFHmacAlgSHA1,
-             PASSWORD,
-             SALT,
-             16777216,
-             DERIVED16777216);
-test_pbkdf2!(pbkdf2_4096_2,
-             kCCPRFHmacAlgSHA1,
-             PASSWORD2,
-             SALT2,
-             4096,
-             DERIVED4096_2);
-test_pbkdf2!(pbkdf2_4096_3,
-             kCCPRFHmacAlgSHA1,
-             PASSWORD3,
-             SALT3,
-             4096,
-             DERIVED4096_3);

--- a/commoncrypto/src/lib.rs
+++ b/commoncrypto/src/lib.rs
@@ -26,3 +26,5 @@ extern crate commoncrypto_sys;
 
 #[warn(missing_docs)]
 pub mod hash;
+#[warn(missing_docs)]
+pub mod pbkdf2;

--- a/commoncrypto/src/pbkdf2.rs
+++ b/commoncrypto/src/pbkdf2.rs
@@ -39,15 +39,23 @@ macro_rules! err_from_cckeyderivationpbkdf_retval {
 }
 
 /// Derive a key from a password or passphrase and a salt
-pub fn pbkdf2(password: &[u8], salt: &[u8], prf: CCPseudoRandomAlgorithm, rounds: u32, key_len: usize) -> io::Result<Vec<u8>> {
+pub fn pbkdf2(password: &[u8],
+              salt: &[u8],
+              prf: CCPseudoRandomAlgorithm,
+              rounds: u32,
+              key_len: usize)
+              -> io::Result<Vec<u8>> {
     let mut pw_derived = vec![0u8; key_len];
     let result = unsafe {
-        CCKeyDerivationPBKDF(
-            CCPBKDFAlgorithm::kCCPBKDF2,
-            password.as_ptr(), password.len(),
-            salt.as_ptr(), salt.len(),
-            prf, rounds,
-            pw_derived.as_mut_ptr(), pw_derived.len())
+        CCKeyDerivationPBKDF(CCPBKDFAlgorithm::kCCPBKDF2,
+                             password.as_ptr(),
+                             password.len(),
+                             salt.as_ptr(),
+                             salt.len(),
+                             prf,
+                             rounds,
+                             pw_derived.as_mut_ptr(),
+                             pw_derived.len())
     };
 
     if result == 0 {

--- a/commoncrypto/src/pbkdf2.rs
+++ b/commoncrypto/src/pbkdf2.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2016
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//! Idiomatic Rust wrapper for `CommonCrypto`'s `CCKeyDerivationPBKDF` function.
+
+use commoncrypto_sys::{CCKeyDerivationPBKDF, CCPBKDFAlgorithm};
+
+use std::io;
+
+pub use commoncrypto_sys::CCPseudoRandomAlgorithm;
+
+macro_rules! err_from_cckeyderivationpbkdf_retval {
+    ($func_name: expr, $val: expr) => {{
+        let kind = match $val {
+            // kCCParamError is the only one that's specifically noted
+            -43000 => io::ErrorKind::InvalidInput,
+            _ => io::ErrorKind::Other,
+        };
+
+        Err(io::Error::new(kind, format!("{} returned nonzero: {}", $func_name, $val)))
+        }}
+}
+
+/// Derive a key from a password or passphrase and a salt
+pub fn pbkdf2(password: &[u8], salt: &[u8], prf: CCPseudoRandomAlgorithm, rounds: u32, key_len: usize) -> io::Result<Vec<u8>> {
+    let mut pw_derived = vec![0u8; key_len];
+    let result = unsafe {
+        CCKeyDerivationPBKDF(
+            CCPBKDFAlgorithm::kCCPBKDF2,
+            password.as_ptr(), password.len(),
+            salt.as_ptr(), salt.len(),
+            prf, rounds,
+            pw_derived.as_mut_ptr(), pw_derived.len())
+    };
+
+    if result == 0 {
+        Ok(pw_derived)
+    } else {
+        err_from_cckeyderivationpbkdf_retval!("CCKeyDerivationPBKDF", result)
+    }
+}

--- a/commoncrypto/tests/pbkdf2.rs
+++ b/commoncrypto/tests/pbkdf2.rs
@@ -1,0 +1,11 @@
+extern crate commoncrypto;
+extern crate hex;
+
+use commoncrypto::pbkdf2::{pbkdf2, CCPseudoRandomAlgorithm};
+use hex::ToHex;
+
+#[test]
+fn derive_pbkdf2() {
+    let derived = pbkdf2(b"password", b"salt", CCPseudoRandomAlgorithm::kCCPRFHmacAlgSHA1, 1, 20).unwrap();
+    assert_eq!("0c60c80f961f0e71f3a9b524af6012062fe037a6", derived.to_hex());
+}

--- a/commoncrypto/tests/pbkdf2.rs
+++ b/commoncrypto/tests/pbkdf2.rs
@@ -6,6 +6,11 @@ use hex::ToHex;
 
 #[test]
 fn derive_pbkdf2() {
-    let derived = pbkdf2(b"password", b"salt", CCPseudoRandomAlgorithm::kCCPRFHmacAlgSHA1, 1, 20).unwrap();
+    let derived = pbkdf2(b"password",
+                         b"salt",
+                         CCPseudoRandomAlgorithm::kCCPRFHmacAlgSHA1,
+                         1,
+                         20)
+        .unwrap();
     assert_eq!("0c60c80f961f0e71f3a9b524af6012062fe037a6", derived.to_hex());
 }


### PR DESCRIPTION
The tests come from [RFC6070](https://tools.ietf.org/html/rfc6070) which only cover SHA-1 but it should be good enough to notice that we get the expected results.

I'm not entirely sure about the best way to return the derived key. Passing a `&mut [u8]` as a last param, essentially what we do in C, would let us know the place where to store the derived key and the user's expected length in a single parameter. While returning the `Result<Vec<u8>>` feels more like what one would expect from a rust function, but it makes us ask for the length explicitly and forces a small dynamic allocation.

Let me know if you feel strongly in either direction.

The `pbkdf2_16777216` test function takes a few seconds to run due to the number of rounds. This is part of the test vectors, but it takes significantly more time to run than the rest of the test suite, so that's something that might be worth removing since we're trusting the underlying implementation to be tested to be correct anyway, we just want to know that a few different parameters are converted correctly.
