### PR TITLE
 refactor: remove libc dependency by using types in libstd

### DIFF
--- a/commoncrypto-sys/Cargo.toml
+++ b/commoncrypto-sys/Cargo.toml
@@ -10,13 +10,8 @@ categories = ["cryptography", "external-ffi-bindings", "os::macos-apis"]
 license = "MIT"
 travis-ci = { repository = "malept/rust-commoncrypto" }
 
-[features]
-lint = ["clippy"]
-
 [dependencies]
 libc = "0.2"
-
-clippy = { version = "0.0", optional = true }
 
 [dev-dependencies]
 hex = "0.3"

--- a/commoncrypto-sys/Cargo.toml
+++ b/commoncrypto-sys/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/malept/rust-commoncrypto"
 keywords = ["crypto", "hash", "digest", "osx", "commoncrypto"]
 categories = ["cryptography", "external-ffi-bindings", "os::macos-apis"]
 license = "MIT"
+
+[badges]
 travis-ci = { repository = "malept/rust-commoncrypto" }
 
 [dev-dependencies]

--- a/commoncrypto-sys/Cargo.toml
+++ b/commoncrypto-sys/Cargo.toml
@@ -10,8 +10,5 @@ categories = ["cryptography", "external-ffi-bindings", "os::macos-apis"]
 license = "MIT"
 travis-ci = { repository = "malept/rust-commoncrypto" }
 
-[dependencies]
-libc = "0.2"
-
 [dev-dependencies]
 hex = "0.3"

--- a/commoncrypto-sys/src/lib.rs
+++ b/commoncrypto-sys/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2017 Mark Lee
+// Copyright (c) 2016, 2017, 2019 Mark Lee
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,9 +22,7 @@
 
 #![warn(missing_docs)]
 
-extern crate libc;
-
-use libc::{c_int, c_uint};
+use std::os::raw::{c_int, c_uint};
 
 /// Total number of operations.
 const MD5_CBLOCK: usize = 64;

--- a/commoncrypto/Cargo.toml
+++ b/commoncrypto/Cargo.toml
@@ -10,13 +10,8 @@ categories = ["cryptography", "api-bindings", "os::macos-apis"]
 license = "MIT"
 travis-ci = { repository = "malept/rust-commoncrypto" }
 
-[features]
-lint = ["clippy"]
-
 [dependencies]
 commoncrypto-sys = { version = "0.2.0", path = "../commoncrypto-sys" }
-
-clippy = { version = "0.0", optional = true }
 
 [dev-dependencies]
 hex = "0.3"

--- a/commoncrypto/Cargo.toml
+++ b/commoncrypto/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/malept/rust-commoncrypto"
 keywords = ["crypto", "hash", "digest", "osx", "commoncrypto"]
 categories = ["cryptography", "api-bindings", "os::macos-apis"]
 license = "MIT"
+
+[badges]
 travis-ci = { repository = "malept/rust-commoncrypto" }
 
 [dependencies]


### PR DESCRIPTION
Extracted from #4.

Also:

* Remove obsolete `clippy` config in `Cargo.toml`
* Fix Travis CI badge config in `Cargo.toml`