### PR TITLE
Enhance CI targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,25 @@
 language: rust
-
 os: osx
-osx_image: xcode11 # 10.14
+cache: cargo
 
-rust:
-- stable
-- beta
-- nightly
-
-cache:
-  cargo: true
+jobs:
+  include:
+    # rustdoc/rustfmt/clippy
+    - stage: style-docs
+      name: "Docs/Formatting/Lints"
+      env: TARGET=all-style-docs
+    - stage: compile-test
+      osx_image: xcode11 # 10.14
+    - osx_image: xcode11 # 10.14
+      rust: beta
+    - osx_image: xcode11 # 10.14
+      rust: nightly
+    - osx_image: xcode6.4 # 10.10
+    - osx_image: xcode8 # 10.11
+    - osx_image: xcode9.2 # 10.12
+    - osx_image: xcode10.1 # 10.13
 
 matrix:
-  include:
-    - osx_image: xcode6.4 # 10.10
-      rust: stable
-    - osx_image: xcode8 # 10.11
-      rust: stable
-    - osx_image: xcode9.2 # 10.12
-      rust: stable
-    - osx_image: xcode10.1 # 10.13
-      rust: stable
   allow_failures:
   - rust: nightly
 
@@ -28,6 +27,10 @@ branches:
   only:
   - master
   - /^v\d+\.\d+\.\d+/
+
+stages:
+- style-docs
+- compile-test
 
 before_script: ci/before_script.sh
 script: ci/script.sh
@@ -37,5 +40,6 @@ after_success:
 env:
   global:
   - PATH=$HOME/.cargo/bin:$PATH
+  - TARGET=x86_64-apple-darwin
   # encrypted github token for doc upload
   - secure: euCXRgSy9cmwmYqigfnM9EQq839onxlWYfVsQf5mw8ERIrKYyVAP1Ca3YVc6IE4klLFDuJIiK7fWCIOAQwTYB5EEc8JigSTum70C4Vmb8U0Ms7L4V2eZ9u45UGR1nf3G2rU4Oo/FxctioAMG9T41J/3l86FgKJEWffQUJqHamknW8l05ZuIkp0qilpUZqTji9eZRX91NidCmMpvJYPBKru40Z7piOLtnpb/r/Ix/iqPCMste5US8KWKtwZoHcJC/Ofu95sN06aoGG37JGn9z4rICSG9v2NcRzMaQ3B4goTRWQ/8wgNh0mt+0MR213Ay7HTjjk8TKKsUB9mNFTyvVoWYAO5vC+LNZLzzogWF2IbhI6If/CcdpHw1Rs9wxs310YlzSPgU1ZON0gRVQj9AYHK436PIPwuBO+pmsAh9ap1ALOnICa5lBvNudNlTL8gOZcYM7EpglBgGsBoAONZWoKv0+Ymm4MFDgVwi8C5oEfz3sdievpfPpl42BWmHsPb99mqZaGxQ76pitTFOYATmgmli7IENq8s9tDur6j0OX6hTR4o41BWQLGTruQG8pexWQ5r3ZryxGjRXAP5xwEz+5zzkQp3RysmcSUCS/lKPPWt7VuRGPdlM49It7uyBD/sPe2fBesEMqvcK94QMNL/xyxkkMcTVnzqSpX81qwEYcJpY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ jobs:
       rust: beta
     - osx_image: xcode11 # 10.14
       rust: nightly
-    - osx_image: xcode6.4 # 10.10
     - osx_image: xcode8 # 10.11
     - osx_image: xcode9.2 # 10.12
     - osx_image: xcode10.1 # 10.13

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 os: osx
-osx_image: xcode7.3 # 10.11
+osx_image: xcode11 # 10.14
 
 rust:
 - stable
@@ -15,7 +15,11 @@ matrix:
   include:
     - osx_image: xcode6.4 # 10.10
       rust: stable
-    - osx_image: xcode8.2 # 10.12
+    - osx_image: xcode8 # 10.11
+      rust: stable
+    - osx_image: xcode9.2 # 10.12
+      rust: stable
+    - osx_image: xcode10.1 # 10.13
       rust: stable
   allow_failures:
   - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ branches:
 before_script: ci/before_script.sh
 script: ci/script.sh
 after_success:
-- if test "$TRAVIS_RUST_VERSION" = "stable"; then cargo coveralls --all --exclude-pattern=/tests/; fi
+- if test "$TRAVIS_RUST_VERSION" = "stable" -a "$TRAVIS_OSX_IMAGE" = "xcode11"; then cargo coveralls --all --exclude-pattern=/tests/; fi
 
 env:
   global:

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -1,5 +1,28 @@
 #!/bin/bash -e
 
+install_target_and_cross() {
+    # Builds for iOS are done on OSX, but require the specific target to be
+    # installed.
+    case $TARGET in
+        *-apple-ios)
+            rustup target install $TARGET
+            ;;
+    esac
+
+    # This fetches latest stable release
+    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/rust-embedded/cross \
+                       | cut -d/ -f3 \
+                       | grep -E '^v[0.1.0-9.]+$' \
+                       | gsort --version-sort \
+                       | tail -n1)
+    curl -LSfs https://japaric.github.io/trust/install.sh | \
+        sh -s -- \
+           --force \
+           --git japaric/cross \
+           --tag $tag \
+            --target x86_64-apple-darwin
+}
+
 cargo_install() {
     local binary="$1"
     local crate="$2"
@@ -15,10 +38,11 @@ cargo_install_update() {
     cargo install-update $crate
 }
 
-cargo_install cargo-install-update cargo-update
-
-if test "$TRAVIS_RUST_VERSION" = "stable" -a "$TRAVIS_OSX_IMAGE" = "xcode11"; then
+if test "$TARGET" = "all-style-docs"; then
+    cargo_install cargo-install-update cargo-update
     cargo_install_update cargo-coverage cargo-travis
     rustup component add rustfmt --toolchain $TRAVIS_RUST_VERSION
     rustup component add clippy --toolchain $TRAVIS_RUST_VERSION
+else
+    install_target_and_cross
 fi

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -17,7 +17,7 @@ cargo_install_update() {
 
 cargo_install cargo-install-update cargo-update
 
-if test "$TRAVIS_RUST_VERSION" = "stable"; then
+if test "$TRAVIS_RUST_VERSION" = "stable" -a "$TRAVIS_OSX_IMAGE" = "xcode11"; then
     cargo_install_update cargo-coverage cargo-travis
     rustup component add rustfmt --toolchain $TRAVIS_RUST_VERSION
     rustup component add clippy --toolchain $TRAVIS_RUST_VERSION

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -18,7 +18,7 @@ run_rustfmt() {
 }
 
 cargo test --all
-if test "$TRAVIS_RUST_VERSION" = "stable"; then
+if test "$TRAVIS_RUST_VERSION" = "stable" -a "$TRAVIS_OSX_IMAGE" = "xcode11"; then
     cargo doc --all
 
     run_rustfmt

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -6,9 +6,9 @@
 run_rustfmt() {
     local changed_rust_files
     if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-        changed_rust_files="$(git diff --name-only "$TRAVIS_COMMIT_RANGE" . | grep \.rs$)"
+        changed_rust_files="$(git diff --name-only "$TRAVIS_COMMIT_RANGE" . | grep \.rs$; true)"
     else
-        changed_rust_files="$(git show --format= --name-only "$TRAVIS_COMMIT_RANGE" . | sort -u | grep \.rs$)"
+        changed_rust_files="$(git show --format= --name-only "$TRAVIS_COMMIT_RANGE" . | gsort -u | grep \.rs$; true)"
     fi
 
     if [[ -n "$changed_rust_files" ]]; then

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -17,10 +17,19 @@ run_rustfmt() {
     echo "Completed rustfmt"
 }
 
-cargo test --all
-if test "$TRAVIS_RUST_VERSION" = "stable" -a "$TRAVIS_OSX_IMAGE" = "xcode11"; then
+if test "$TARGET" = "all-style-docs"; then
     cargo doc --all
 
     run_rustfmt
     cargo clippy --all -- --allow clippy::pedantic
+else
+    cross build --target $TARGET
+    cross build --target $TARGET --release
+
+    if [ ! -z $DISABLE_TESTS ]; then
+        return
+    fi
+
+    cross test --target $TARGET
+    cross test --target $TARGET --release
 fi


### PR DESCRIPTION
* Run CI against macOS 10.13 and 10.14 as well
* Use Travis CI stages to run rustdoc/rustfmt/clippy once before the compilation/test stage
* Use `cross` to build/test